### PR TITLE
Prevent multiplayer desyncs

### DIFF
--- a/ZScript.txt
+++ b/ZScript.txt
@@ -86,6 +86,7 @@ class HDB_Tracer : Actor
 		+NOGRAVITY
 		+NOBLOCKMAP
 		FloatBobPhase 0; // for some reason, this thing uses rng, which causes desyncs
+		+SYNCHRONIZED;
 		RenderStyle "Add";
 	}
 }

--- a/ZScript.txt
+++ b/ZScript.txt
@@ -122,7 +122,7 @@ class HDB_Tracer : Actor
 		+BRIGHT
 		+NOGRAVITY
 		+NOBLOCKMAP
-		+CLIENTSIDEONLY
+		FloatBobPhase 0; // for some reason, this thing uses rng, which causes desyncs
 		RenderStyle "Add";
 	}
 }

--- a/ZScript.txt
+++ b/ZScript.txt
@@ -6,58 +6,21 @@ version "4.6"
 class HDB_TracerHandler : EventHandler
 {	
 
-	private double alphaFadeActual;
-	private double alphaInitialActual;
-	private bool   fragSpawningActual;
-	private bool   buckSpawningActual;
-	private bool   isEnabled;
-	private bool   cvarsAvailable;
-	
-	private Transient Cvar holder;
-
-	void initialize()
-	{
-		holder = Cvar.GetCvar("trc_initial_alpha", players[consolePlayer]);
-		if(holder)alphaInitialActual     = double(holder.getFloat());
-		
-		holder = Cvar.GetCvar("trc_fade_amount",    players[consolePlayer]);
-		if(holder)alphaFadeActual        = double(holder.getFloat());
-		
-		holder = Cvar.GetCvar("trc_frags",          players[consolePlayer]);
-		if(holder)fragSpawningActual     = bool(holder.getInt());
-		
-		holder = Cvar.GetCvar("trc_bucks",          players[consolePlayer]);
-		if(holder)buckSpawningActual     = bool(holder.getBool());
-		
-		holder = Cvar.GetCvar("trc_enabled",        players[consolePlayer]);
-		if(holder)isEnabled              = bool(holder.getBool());
-		
-		cvarsAvailable = true;
-	}
-
-	override void worldTick()
-	{
-		if (!cvarsavailable)
-		{
-		  initialize();
-		}
-	}
-
 	override void WorldThingSpawned(WorldEvent e)
 	{
 		class<Actor> type;	
 		HDBulletActor b = HDBulletActor(e.Thing);
 		
-		if (!cvarsAvailable || !isEnabled || !b) return;
+		if (!trc_enabled || !b) return;
 		
 		switch(e.thing.getclassname())
 		{
 			case 'HDB_frag':
-				if(!fragSpawningActual)return;
+				if(!trc_frags)return;
 				break;
 				
 			case 'HDB_00':
-				if(!buckSpawningActual)return;
+				if(!trc_bucks)return;
 				break;
 				
 			default:
@@ -79,8 +42,8 @@ class HDB_TracerHandler : EventHandler
 		lz.angle = b.angle;
 		lz.scale.y = b.vel.length();
 		
-		lz.alpha      = alphaInitialActual;
-		lz.fadeamount = alphaFadeActual;
+		lz.alpha      = trc_initial_alpha;
+		lz.fadeamount = trc_fade_amount;
 		// Uncomment this if using vel ever works better. 
 		//lz.vel = b.vel;
 

--- a/cvarinfo.txt
+++ b/cvarinfo.txt
@@ -1,6 +1,6 @@
 // They're already trc-er.  
-user float trc_initial_alpha = 1.00;
-user float trc_fade_amount   = 0.25;
-user bool  trc_enabled       = true;
-user bool  trc_frags         = true;
-user bool  trc_bucks         = true;
+nosave float trc_initial_alpha = 1.00;
+nosave float trc_fade_amount   = 0.25;
+nosave bool  trc_enabled       = true;
+nosave bool  trc_frags         = true;
+nosave bool  trc_bucks         = true;


### PR DESCRIPTION
Should prevent multiplayer desyncs when the other clients aren't using the addon.

List of changes:
* `HDB_Tracer` now uses `FloatBobPhase 0` and `+SYNCHRONIZED` instead of `+CLIENTSIDEONLY`, as `FloatBobPhase` and `-SYNCHRONIZED` apparently does some RNG calls, which leads to desyncs.
* Changed `user` CVars to `nosave`, makes things "more clientsided" i guess (also cvar changes are now immediate)